### PR TITLE
Use GitHub Actions as committer for scheduled updates

### DIFF
--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -33,3 +33,6 @@ jobs:
           commit_message: Update graphs by scheduler
           branch: ${{ github.ref }}
           file_pattern: outputs/*.svg
+          commit_user_name: GitHub Actions
+          commit_user_email: actions@github.com
+          commit_author: GitHub Actions <actions@github.com>

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Claude Code
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Configure the GitHub Actions workflow to use "GitHub Actions" as the committer instead of personal account
- Add CLAUDE.md to .gitignore to allow contributors to customize their own versions
- Automated daily commits will now be attributed to actions@github.com

## Changes
- Updated `.github/workflows/auto_update.yml` to set `commit_user_name`, `commit_user_email`, and `commit_author` 
- Added `CLAUDE.md` to `.gitignore` for contributor customization

This ensures that the daily CRON job commits are properly attributed to the automation rather than appearing as personal commits.

🤖 Generated with [Claude Code](https://claude.ai/code)